### PR TITLE
Fix scrolling to bottom of results window.

### DIFF
--- a/NetBash/UI/script-js.js
+++ b/NetBash/UI/script-js.js
@@ -54,7 +54,7 @@ function NetBash($, window, opt) {
         clearTimeout(showLoader);
         $("#console-input").removeClass("loading");
 
-        $("#console-result").scrollTop($("#console-result").attr("scrollHeight"));
+        $("#console-result").scrollTop($("#console-result")[0].scrollHeight);
     };
 
     this.openConsole = function () {
@@ -69,6 +69,7 @@ function NetBash($, window, opt) {
         }, 100, function () {
             isOpen = true;
         });
+        self.scrollBottom();
     };
 
     this.closeConsole = function () {

--- a/NetBash/UI/script-js.js
+++ b/NetBash/UI/script-js.js
@@ -117,7 +117,7 @@ function NetBash($, window, opt) {
                             $('<div class="console-response"/>').html(data.Content).appendTo('#console-result');
                         } else {
                             //pre that shit
-                            $('<pre class="console-response"/>').html(data.Content).appendTo('#console-result');
+                            $('<pre class="console-response">' + data.Content + '</pre>').appendTo('#console-result');
                         }
                     } else {
                         self.setError(data.Content);


### PR DESCRIPTION
The results window never scrolled after a command was sent for me, this fix resolved it. 
Also resolves issue #14 "Console needs to auto scroll when brought up". 

Tested in Chrome 16.0.912.75 and Firefox 7.0.1

Regards,

Paul Heasley
