### PR TITLE
Fix new lines in IE8

### DIFF
--- a/NetBash/UI/script-js.js
+++ b/NetBash/UI/script-js.js
@@ -116,7 +116,7 @@ function NetBash($, window, opt) {
                             $('<div class="console-response"/>').html(data.Content).appendTo('#console-result');
                         } else {
                             //pre that shit
-                            $('<pre class="console-response"/>').html(data.Content).appendTo('#console-result');
+                            $('<pre class="console-response">' + data.Content + '</pre>').appendTo('#console-result');
                         }
                     } else {
                         self.setError(data.Content);


### PR DESCRIPTION
Allows new lines in IE 8, previously all text appeared on one line.
