### PR TITLE
Add ability to redirect to file

### DIFF
--- a/NetBash/CommandResult.cs
+++ b/NetBash/CommandResult.cs
@@ -9,5 +9,6 @@ namespace NetBash
     {
         public string Result { get; set; }
         public bool IsHtml { get; set; }
+        public string FileName { get; set; }
     }
 }

--- a/NetBash/NetBash.cs
+++ b/NetBash/NetBash.cs
@@ -73,7 +73,14 @@ namespace NetBash
             var webCommand = (IWebCommand)Activator.CreateInstance(commandType);
 
             var result = new CommandResult() { IsHtml = webCommand.ReturnHtml };
-            result.Result = webCommand.Process(split.Skip(1).ToArray());
+            // Check for file redirect
+            var args = split.Skip(1).ToArray();
+            if (args.Length >= 2 && args[args.Length - 2] == ">")
+            {
+                result.FileName = args[args.Length - 1];
+                Array.Resize(ref args, args.Length - 2);
+            }
+            result.Result = webCommand.Process(args);
 
             return result;
         }

--- a/NetBash/UI/script-js.js
+++ b/NetBash/UI/script-js.js
@@ -101,7 +101,18 @@ function NetBash($, window, opt) {
         if (text == "clear") {
             $("#console-result").html("");
             clearStorage();
-        } else {
+        } else { 
+            // Check for file redirect
+            var args = $.grep(text.split(/("[^"]*")|([^\s]+)/g), function(n) { return ($.trim(n)); });
+            if (args.length > 2 && args[args.length - 2] == ">") {
+                $('<form action="' + options.routeBasePath + 'netbash-export" method="post" style="display:none;"></form>')
+                    .append($('<input type="text" name="Command"></input>').val(text))
+                    .appendTo('body')
+                    .submit()
+                    .remove();
+                return;
+            }
+
             self.startLoader();
 
             //send command


### PR DESCRIPTION
Patch that adds the ability to redirect output to a file that the user is prompted to download.
#### Usage:

help > help.txt
length test string > length.txt

Implemented export as a separate action / url to call that returns type application/octet-stream rather than json.
Javascript recognised redirect symbol '>' and instead of performing an ajax call, sends a form submission to the netbash-export url. 
#### Known issues

The problem with this implementation is that if an error occurs the whole page is replaced by the error. This could be overcome by using an iframe for the down, then retrieve any error messages to display back in the console.
